### PR TITLE
Implement intermediate frame support

### DIFF
--- a/modules/interface.py
+++ b/modules/interface.py
@@ -412,7 +412,7 @@ def create_interface(
                         # --- END OF REFACTORED XY PLOT SECTION ---
 
                         with gr.Group(visible=True) as standard_generation_group:    # Default visibility: True because "Original" model is not "Video"
-                            with gr.Group(visible=True) as image_input_group: # This group now only contains the start frame image
+                            with gr.Group(visible=True) as image_input_group: # This group now contains start and additional frames
                                 with gr.Row():
                                     with gr.Column(scale=1): # Start Frame Image Column
                                         input_image = gr.Image(
@@ -424,6 +424,12 @@ def create_interface(
                                             show_download_button=False,
                                             show_label=True, # Keep label for clarity
                                             container=True
+                                        )
+                                    with gr.Column(scale=1): # Additional Frames Column
+                                        additional_frames = gr.Files(
+                                            label="Additional Frames (optional)",
+                                            file_count="multiple",
+                                            file_types=["image"]
                                         )
                             
                             with gr.Group(visible=False) as video_input_group:
@@ -1120,6 +1126,7 @@ def create_interface(
             # The order here MUST match the order in the `ips` list.
             # RT_BORG: Global settings gpu_memory_preservation, mp4_crf, save_metadata removed from direct args.
             (input_image_arg,
+             additional_frames_arg,
              input_video_arg,
              end_frame_image_original_arg,
              end_frame_strength_original_arg,
@@ -1174,7 +1181,7 @@ def create_interface(
             # Use the current seed value as is for this job
             # Call the process function with all arguments
             # Pass the backend_model_type and the ORIGINAL prompt_text string to the backend process function
-            result = process_fn(backend_model_type, input_data, actual_end_frame_image_for_backend, actual_end_frame_strength_for_backend,
+            result = process_fn(backend_model_type, input_data, additional_frames_arg, actual_end_frame_image_for_backend, actual_end_frame_strength_for_backend,
                                 prompt_text_arg, n_prompt_arg, seed_arg, total_second_length_arg,
                                 latent_window_size_arg, steps_arg, cfg_arg, gs_arg, rs_arg,
                                 use_teacache_arg, teacache_num_steps_arg, teacache_rel_l1_thresh_arg,
@@ -1259,6 +1266,7 @@ def create_interface(
         # --- Inputs for all models ---
         ips = [
             input_image,                # Corresponds to input_image_arg
+            additional_frames,          # Corresponds to additional_frames_arg
             input_video,                # Corresponds to input_video_arg
             end_frame_image_original,   # Corresponds to end_frame_image_original_arg
             end_frame_strength_original,# Corresponds to end_frame_strength_original_arg

--- a/modules/pipelines/original_with_endframe_pipeline.py
+++ b/modules/pipelines/original_with_endframe_pipeline.py
@@ -137,7 +137,18 @@ class OriginalWithEndframePipeline(BasePipeline):
             
             # Store the processed end frame image
             processed_inputs['end_frame_image'] = end_frame_np
-        
+
+        # Process additional frames if provided
+        additional_frames = job_params.get('additional_frames')
+        if additional_frames:
+            height = processed_inputs['height']
+            width = processed_inputs['width']
+            processed_frames = []
+            for frame in additional_frames:
+                frame_np = resize_and_center_crop(frame, target_width=width, target_height=height)
+                processed_frames.append(frame_np)
+            processed_inputs['additional_frames'] = processed_frames
+
         return processed_inputs
     
     def handle_results(self, job_params, result):

--- a/modules/pipelines/worker.py
+++ b/modules/pipelines/worker.py
@@ -54,6 +54,7 @@ def get_cached_or_encode_prompt(prompt, text_encoder, text_encoder_2, tokenizer,
 def worker(
     model_type,
     input_image,
+    additional_frames,
     end_frame_image,     # The end frame image (numpy array or None)
     end_frame_strength,  # Influence of the end frame
     prompt_text, 
@@ -475,6 +476,21 @@ def worker(
                     end_clip_embedding = hf_clip_vision_encode(end_frame_np, feature_extractor, image_encoder).last_hidden_state
                     end_clip_embedding = end_clip_embedding.to(studio_module.current_generator.transformer.dtype)
                     # Need that dtype conversion for end_clip_embedding? I don't think so, but it was in the original PR.
+
+        # Process additional frames if provided
+        additional_frame_latents = []
+        if model_type == "Original with Endframe" and job_params.get('additional_frames'):
+            for frame_np in job_params['additional_frames']:
+                frame_pt = torch.from_numpy(frame_np).float() / 127.5 - 1
+                frame_pt = frame_pt.permute(2, 0, 1)[None, :, None]
+                if not high_vram:
+                    load_model_as_complete(vae, target_device=gpu)
+                from diffusers_helper.hunyuan import vae_encode
+                lat = vae_encode(frame_pt, vae)
+                additional_frame_latents.append(lat)
+            if not high_vram:
+                offload_model_from_device_for_memory_preservation(vae, target_device=gpu, preserved_memory_gb=settings.get("gpu_memory_preservation"))
+            print(f"Processed {len(additional_frame_latents)} additional frame latents")
         
         if not high_vram: # Offload VAE and image_encoder if they were loaded
             offload_model_from_device_for_memory_preservation(vae, target_device=gpu, preserved_memory_gb=settings.get("gpu_memory_preservation"))
@@ -515,6 +531,13 @@ def worker(
         
         # Get latent paddings from the generator
         latent_paddings = studio_module.current_generator.get_latent_paddings(total_latent_sections)
+
+        # Determine which sections will receive additional frame latents
+        apply_schedule = {}
+        if model_type == "Original with Endframe" and (end_frame_latent is not None or additional_frame_latents):
+            frame_latents_sequence = [end_frame_latent] + additional_frame_latents
+            indices = np.linspace(0, len(latent_paddings) - 1, len(frame_latents_sequence), dtype=int)
+            apply_schedule = {int(i): lat for i, lat in zip(indices, frame_latents_sequence) if lat is not None}
 
         # PROMPT BLENDING: Track section index
         section_idx = 0
@@ -715,11 +738,12 @@ def worker(
                   f'time position: {current_time_position:.2f}s (original: {original_time_position:.2f}s), '
                   f'using prompt: {current_prompt[:60]}...')
 
-            # Apply end_frame_latent to history_latents for models with Endframe support
-            if (model_type == "Original with Endframe") and i_section_loop == 0 and end_frame_latent is not None:
-                print(f"Applying end_frame_latent to history_latents with strength: {end_frame_strength}")
-                actual_end_frame_latent_for_history = end_frame_latent.clone()
-                if end_frame_strength != 1.0: # Only multiply if not full strength
+            # Apply scheduled frame latents for models with Endframe support
+            if (model_type == "Original with Endframe") and i_section_loop in apply_schedule:
+                latent_to_apply = apply_schedule[i_section_loop].clone()
+                print(f"Applying scheduled frame latent at section {i_section_loop} with strength: {end_frame_strength}")
+                actual_end_frame_latent_for_history = latent_to_apply
+                if end_frame_strength != 1.0:
                     actual_end_frame_latent_for_history = actual_end_frame_latent_for_history * end_frame_strength
                 
                 # Ensure history_latents is on the correct device (usually CPU for this kind of modification if it's init'd there)

--- a/modules/xy_plot_ui.py
+++ b/modules/xy_plot_ui.py
@@ -118,6 +118,7 @@ def xy_plot_process(
         "input_image": input_image,
         "end_frame_image": None,
         "end_frame_strength": 1.0,
+        "additional_frames": [],
         "input_video": None,
         "end_frame_image_original": end_frame_image_original,
         "end_frame_strength_original": end_frame_strength_original,

--- a/studio.py
+++ b/studio.py
@@ -304,6 +304,7 @@ job_queue.set_worker_function(worker)
 def process(
         model_type,
         input_image,
+        additional_frames,
         end_frame_image,     # NEW
         end_frame_strength,  # NEW        
         prompt_text,
@@ -391,6 +392,29 @@ def process(
             print(f"Copied end frame image to {end_frame_image_path}")
         except Exception as e:
             print(f"Error copying end frame image: {e}")
+
+    # Process additional frames if provided
+    processed_additional_frames = []
+    if additional_frames:
+        for frame in additional_frames:
+            frame_path = None
+            if isinstance(frame, str) and os.path.exists(frame):
+                frame_path = frame
+            elif hasattr(frame, "name") and os.path.exists(frame.name):
+                frame_path = frame.name
+            if frame_path:
+                try:
+                    filename = os.path.basename(frame_path)
+                    copied_path = os.path.join(input_files_dir, f"{generate_timestamp()}_{filename}")
+                    shutil.copy2(frame_path, copied_path)
+                    print(f"Copied additional frame to {copied_path}")
+                    frame_np = np.array(Image.open(copied_path).convert("RGB"))
+                except Exception as e:
+                    print(f"Error copying additional frame: {e}")
+                    frame_np = np.array(Image.open(frame_path).convert("RGB"))
+            else:
+                frame_np = np.array(frame) if not isinstance(frame, np.ndarray) else frame
+            processed_additional_frames.append(frame_np)
     
     # Extract lora_loaded_names from lora_args
     lora_loaded_names = lora_args[0] if lora_args and len(lora_args) > 0 else []
@@ -425,6 +449,7 @@ def process(
         'end_frame_image_path': end_frame_image_path,  # Add the path to the copied end frame image
         'resolutionW': resolutionW, # Add resolution parameter
         'resolutionH': resolutionH,
+        'additional_frames': processed_additional_frames,
         'lora_loaded_names': lora_loaded_names,
         'combine_with_source': combine_with_source,  # Add combine_with_source parameter
         'num_cleaned_frames': num_cleaned_frames,


### PR DESCRIPTION
## Summary
- add UI element for uploading additional frames
- include additional frames in job params and XY plot defaults
- preprocess additional frames for the original-with-endframe pipeline
- encode additional frames to latents and schedule them during generation

## Testing
- `python -m py_compile studio.py modules/interface.py modules/pipelines/worker.py modules/pipelines/original_with_endframe_pipeline.py modules/xy_plot_ui.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684bb3341ed08321b50cd4c1a1ce99fc